### PR TITLE
Add git url.

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,6 +14,9 @@ dependencies:
   mockito: ^5.2.0
   provider: ^6.0.3
   stager:
+    git:
+      url: git@github.com:bryanoltman/stager.git
+      ref: main
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
 If I have my application and I want to reference the stager in github as dependency, i need github url. 
Added the url to example to make it easier for users to adopt the tool.