### PR TITLE
Add support for Dart 3.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,11 +5,11 @@ repository: https://github.com/bryanoltman/stager
 issue_tracker: https://github.com/bryanoltman/stager/issues
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
   flutter: ">=1.16.0"
 
 dependencies:
-  analyzer: ^4.7.0
+  analyzer: ^5.0.0
   build: ^2.3.0
   flutter:
     sdk: flutter


### PR DESCRIPTION
This updates the upper SDK bound to support development builds of the SDK which are already using the 3.0.0 SDK bound. The `package:analyzer` constraints have also been updated to pull in recent bug fixes.