### PR TITLE
Better support for large screens

### DIFF
--- a/lib/src/control_panel/display_size_picker.dart
+++ b/lib/src/control_panel/display_size_picker.dart
@@ -56,14 +56,14 @@ class _DisplaySizePickerState extends State<DisplaySizePicker> {
             screenSize.height.toStringAsFixed(0);
         _widthTextEditingController.text = screenSize.width.toStringAsFixed(0);
       });
-    });
 
-    _heightTextEditingController.addListener(
-      () => widget.didChangeSize(width, height),
-    );
-    _widthTextEditingController.addListener(
-      () => widget.didChangeSize(width, height),
-    );
+      _heightTextEditingController.addListener(
+        () => widget.didChangeSize(width, height),
+      );
+      _widthTextEditingController.addListener(
+        () => widget.didChangeSize(width, height),
+      );
+    });
   }
 
   @override

--- a/lib/src/control_panel/display_size_picker.dart
+++ b/lib/src/control_panel/display_size_picker.dart
@@ -11,8 +11,13 @@ class DisplaySizePicker extends StatefulWidget {
   /// several [ScreenSizePreset]s or manually enter width and height values.
   const DisplaySizePicker({
     super.key,
+    required this.defaultSize,
     required this.didChangeSize,
   });
+
+  /// The initial value of this control. This value is also used when no size
+  /// preset is selected.
+  final Size defaultSize;
 
   /// Called when the width or height values are updated, either by text input
   /// or by the user selecting one of the [ScreenSizePreset]s.
@@ -45,7 +50,7 @@ class _DisplaySizePickerState extends State<DisplaySizePicker> {
     _widthTextEditingController = TextEditingController();
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      final Size screenSize = MediaQuery.of(context).size;
+      final Size screenSize = widget.defaultSize;
       setState(() {
         _heightTextEditingController.text =
             screenSize.height.toStringAsFixed(0);
@@ -126,8 +131,7 @@ class _DisplaySizePickerState extends State<DisplaySizePicker> {
                 value: _selectedScreenSizePreset,
                 onChanged: (ScreenSizePreset? newValue) {
                   _selectedScreenSizePreset = newValue;
-                  final Size newSize =
-                      newValue?.size ?? MediaQuery.of(context).size;
+                  final Size newSize = newValue?.size ?? widget.defaultSize;
                   _heightTextEditingController.text =
                       newSize.height.toStringAsFixed(0);
                   _widthTextEditingController.text =

--- a/lib/src/scene_container.dart
+++ b/lib/src/scene_container.dart
@@ -29,6 +29,7 @@ class SceneContainer extends StatefulWidget {
 
 class _SceneContainerState extends State<SceneContainer> {
   static const Duration _panelAnimationDuration = Duration(milliseconds: 250);
+  static const double _panelDividerWidth = 1;
 
   Key _containerKey = UniqueKey();
   bool _isControlPanelExpanded = false;
@@ -45,41 +46,31 @@ class _SceneContainerState extends State<SceneContainer> {
     setState(() => _containerKey = UniqueKey());
   }
 
-  double get panelWidth => min(MediaQuery.of(context).size.width * 0.75, 300);
+  double get _panelWidth => min(MediaQuery.of(context).size.width * 0.75, 300);
   bool get isSmallScreen => MediaQuery.of(context).size.width < 600;
-  static const double _panelDividerWidth = 1;
 
   Size get _defaultSceneSize {
     final Size viewportSize = MediaQuery.of(context).size;
     return isSmallScreen
         ? viewportSize
         : Size(
-            viewportSize.width - panelWidth - _panelDividerWidth,
+            viewportSize.width - _panelWidth - _panelDividerWidth,
             viewportSize.height,
           );
   }
 
-  double get sceneHeight {
+  double get _sceneHeight {
     return _heightOverride?.toDouble() ?? MediaQuery.of(context).size.height;
   }
 
-  double get sceneWidth {
-    if (_widthOverride == null) {
-      return MediaQuery.of(context).size.width -
-          panelWidth -
-          _panelDividerWidth;
-    }
-
-    // if (isSmallScreen) {
-    return _widthOverride!.toDouble();
-    // }
-
-    // return MediaQuery.of(context).size.width - panelWidth - _panelDividerWidth;
+  double get _sceneWidth {
+    return _widthOverride?.toDouble() ??
+        MediaQuery.of(context).size.width - _panelWidth - _panelDividerWidth;
   }
 
   Widget _panel() {
     return SizedBox(
-      width: panelWidth,
+      width: _panelWidth,
       child: EnvironmentControlPanel(
         targetPlatform: _targetPlatform,
         children: <Widget>[
@@ -182,8 +173,8 @@ class _SceneContainerState extends State<SceneContainer> {
         data: Theme.of(context).copyWith(platform: _targetPlatform),
         child: SizedBox(
           key: _containerKey,
-          width: sceneWidth,
-          height: sceneHeight,
+          width: _sceneWidth,
+          height: _sceneHeight,
           child: ClipRect(
             child: _showSemantics
                 ? SemanticsDebugger(child: widget.scene.build())
@@ -194,7 +185,9 @@ class _SceneContainerState extends State<SceneContainer> {
     );
   }
 
-  Widget _smallScreenContainer() {
+  /// A layout for narrower screens that makes the [EnvironmentControlPanel]
+  /// collapsible.
+  Widget _smallScreenLayout() {
     return Stack(
       alignment: Alignment.center,
       children: <Widget>[
@@ -203,7 +196,7 @@ class _SceneContainerState extends State<SceneContainer> {
           padding: EdgeInsets.zero,
           alignment: Alignment.centerLeft,
           transform: Matrix4.translationValues(
-            _isControlPanelExpanded ? 0 : -panelWidth,
+            _isControlPanelExpanded ? 0 : -_panelWidth,
             0,
             0,
           ),
@@ -239,7 +232,9 @@ class _SceneContainerState extends State<SceneContainer> {
     );
   }
 
-  Widget _largeScreenContainer() {
+  /// A master-detail layout that makes the [EnvironmentControlPanel]
+  /// non-collapsible.
+  Widget _largeScreenLayout() {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[
@@ -260,7 +255,7 @@ class _SceneContainerState extends State<SceneContainer> {
   Widget build(BuildContext context) {
     return Material(
       color: Colors.black,
-      child: isSmallScreen ? _smallScreenContainer() : _largeScreenContainer(),
+      child: isSmallScreen ? _smallScreenLayout() : _largeScreenLayout(),
     );
   }
 }

--- a/lib/src/scene_container.dart
+++ b/lib/src/scene_container.dart
@@ -64,8 +64,17 @@ class _SceneContainerState extends State<SceneContainer> {
   }
 
   double get _sceneWidth {
-    return _widthOverride?.toDouble() ??
-        MediaQuery.of(context).size.width - _panelWidth - _panelDividerWidth;
+    if (_widthOverride != null) {
+      return _widthOverride!.toDouble();
+    }
+
+    final double screenWidth = MediaQuery.of(context).size.width;
+
+    if (isSmallScreen) {
+      return screenWidth;
+    }
+
+    return screenWidth - _panelWidth - _panelDividerWidth;
   }
 
   Widget _panel() {

--- a/test/environment_control_panel_test.dart
+++ b/test/environment_control_panel_test.dart
@@ -4,6 +4,12 @@ import 'package:stager/src/control_panel/environment_control_panel.dart';
 import 'package:stager/stager.dart';
 
 void main() {
+  // Test dimensions are 800x600
+  // The EnvironmentControlPanel is 300px wide, and there is a 1px divider to
+  // its right.
+  // 800 - 300 - 1 = 499
+  const double defaultSceneContainerWidth = 499;
+
   MediaQuery sceneContainerMediaQuery() {
     return find
         .byKey(const ValueKey<String>('SceneContainerMediaQuery'))
@@ -16,10 +22,6 @@ void main() {
     final StagerApp stagerApp =
         StagerApp(scenes: <Scene>[EnvironmentControlScene()]);
     await tester.pumpWidget(stagerApp);
-    await tester.pumpAndSettle();
-    await tester.tap(
-      find.byKey(const ValueKey<String>('ToggleEnvironmentControlPanelButton')),
-    );
     await tester.pumpAndSettle();
   }
 
@@ -164,7 +166,7 @@ void main() {
       await createAppAndShowControlPanel(tester);
 
       expect(findSceneFrame().height, 600);
-      expect(findSceneFrame().width, 800);
+      expect(findSceneFrame().width, defaultSceneContainerWidth);
 
       await tester.enterText(
         find.byKey(const ValueKey<String>('DisplayWidthTextField')),
@@ -190,7 +192,7 @@ void main() {
       await createAppAndShowControlPanel(tester);
 
       expect(findSceneFrame().height, 600);
-      expect(findSceneFrame().width, 800);
+      expect(findSceneFrame().width, defaultSceneContainerWidth);
 
       await tester.tap(find.text('Current Window'));
       await tester.pumpAndSettle();

--- a/test/scene_container_test.dart
+++ b/test/scene_container_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stager/stager.dart';
+
+void main() {
+  testWidgets('collapses EnvironmentControlPanel on narrow screens',
+      (WidgetTester tester) async {
+    tester.binding.window.physicalSizeTestValue = const Size(500, 600);
+    tester.binding.window.devicePixelRatioTestValue = 1.0;
+
+    final StagerApp stagerApp = StagerApp(scenes: <Scene>[TextScene()]);
+    await tester.pumpWidget(stagerApp);
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey<String>('ToggleEnvironmentControlPanelButton')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('expands EnvironmentControlPanel on larger screens',
+      (WidgetTester tester) async {
+    tester.binding.window.physicalSizeTestValue = const Size(2160, 3840);
+    tester.binding.window.devicePixelRatioTestValue = 1.0;
+
+    final StagerApp stagerApp = StagerApp(scenes: <Scene>[TextScene()]);
+    await tester.pumpWidget(stagerApp);
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey<String>('ToggleEnvironmentControlPanelButton')),
+      findsNothing,
+    );
+  });
+}
+
+class TextScene extends Scene {
+  @override
+  String get title => 'Text';
+
+  @override
+  Widget build() {
+    return const Text('Text Scene');
+  }
+}

--- a/test/stager_app_test.dart
+++ b/test/stager_app_test.dart
@@ -30,12 +30,6 @@ void main() {
     // Verify that our SceneContainer is present.
     expect(find.byType(SceneContainer), findsOneWidget);
 
-    // Expand the EnvironmentControlPanel.
-    await tester.tap(
-      find.byKey(const ValueKey<String>('ToggleEnvironmentControlPanelButton')),
-    );
-    await tester.pumpAndSettle();
-
     // Verify that tapping the back button navigates back.
     await tester.tap(find.byKey(
       const ValueKey<String>('PopToSceneListButton'),


### PR DESCRIPTION
For screens wider than 600px, show the EnvironmentControlPanel to the left of the scene instead of as an overlay. For more narrow screens, the behavior is unchanged.

Fixes #17

Large screen:
![Screenshot 2023-02-24 at 4 51 57 PM](https://user-images.githubusercontent.com/581764/221300156-7a3194ca-e338-4fdd-b5a4-e2e83f4e9b99.png)

Small screen:
![simulator_screenshot_E3FB7533-79F7-4EDD-A579-DE1E33F07691](https://user-images.githubusercontent.com/581764/221299998-682cb1cb-e90b-4c3a-805a-d29a5aaebf87.png)
