### PR TITLE
Upgrade analyzer dependency to > 6.0.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+- Upgrade the `analyzer` dependency to `^6.0.0`.
+
 ## 1.0.1
 
 - Upgrade to newer analyzer.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.16.0"
 
 dependencies:
-  analyzer: ">=5.1.0 <6.0.0"
+  analyzer: ^6.0.0
   build: ^2.3.1
   flutter:
     sdk: flutter


### PR DESCRIPTION
The analyzer dependency constraints for stager were breaking for the latest flutter, where package:test depends on analyzer > 6.0.0.

Once this lands, we will need a new publish of the stager package. Thanks! @bryanoltman 