### PR TITLE
Widen the analyzer version constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.2.0
+## 1.1.0
 
 - Widen the `analyzer` dependency version constraint to `'>=5.1.0 <8.0.0'`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.2.0
 
-- Upgrade the `analyzer` dependency to `^6.0.0`.
+- Widen the `analyzer` dependency version constraint to `'>=5.1.0 <8.0.0'`.
 
 ## 1.0.1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.16.0"
 
 dependencies:
-  analyzer: ^6.0.0
+  analyzer: '>=5.1.0 <8.0.0'
   build: ^2.3.1
   flutter:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stager
 description: A Flutter productivity tool that allows developers to isolate pieces of UI.
-version: 1.0.1
+version: 1.1.0
 repository: https://github.com/bryanoltman/stager
 issue_tracker: https://github.com/bryanoltman/stager/issues
 


### PR DESCRIPTION
Follow up to https://github.com/bryanoltman/stager/pull/48 after receiving feedback that the constraints should be widened.

Stager 1.1.0 should be published after this PR lands. @bryanoltman 